### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/ALEXFLORESF/e0c36765-fb74-4b3a-bbdd-90251874e738/55554df1-865e-406b-b988-ac0bf01c32dd/_apis/work/boardbadge/6bbe6a3b-ed9d-4363-98b1-bf21d9426c34)](https://dev.azure.com/ALEXFLORESF/e0c36765-fb74-4b3a-bbdd-90251874e738/_boards/board/t/55554df1-865e-406b-b988-ac0bf01c32dd/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ALEXFLORESF/e0c36765-fb74-4b3a-bbdd-90251874e738/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.